### PR TITLE
docker-compose for alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,14 @@ ARG DOCKER_VERSION=1.13.1
 ARG DOCKER_COMPOSE_VERSION=1.14.0
 RUN apk --update --no-cache add tar curl git \
     && curl -fsSL https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION.tgz | tar --strip-components=1 -xz -C /usr/local/bin docker/docker
+
+# glibc for docker-compose from https://github.com/docker/compose/blob/master/Dockerfile.run
+ARG GLIBC=2.23-r3
+RUN apk update && apk add --no-cache openssl ca-certificates && \
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/glibc-$GLIBC.apk && \
+    apk add --no-cache glibc-$GLIBC.apk && rm glibc-$GLIBC.apk && \
+    ln -s /lib/libz.so.1 /usr/glibc-compat/lib/ && \
+    ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib
+
+RUN curl -fsSL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
Installing glibc as documented in https://github.com/docker/compose/blob/master/Dockerfile.run

```
$ docker run -ti --rm  cloudbees/java-with-docker-client:alpine docker-compose version
docker-compose version 1.14.0, build c7bdf9e
docker-py version: 2.3.0
CPython version: 2.7.13
OpenSSL version: OpenSSL 1.0.1t  3 May 2016
```

